### PR TITLE
検索された時のタイトルと小見出しの内容を改善

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -5,7 +5,12 @@
   <meta http-equiv="X-FRAME-OPTIONS" content="SAMEORIGIN" />
   <meta name="viewport" content="width=device-width" />
   <meta name="description" content="<%= site.description %> <%- sidebar.about %>" />
-  <title><%= pageTitle %> - <%= site.name %></title>
+  <title><% 
+    if (pageTitle==="Index") { 
+      %><%= site.name %><% 
+    } else {
+      %><%= pageTitle %> - <%= site.name %><% 
+    } %></title>
   <link rel="stylesheet" href="/theme/<%= site.theme %>/<%= site.theme %>.css" />
   <link rel="stylesheet" href="/css/common.css" />
   <link rel="stylesheet" href="/lib/exvalidation/exvalidation.css" />

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-FRAME-OPTIONS" content="SAMEORIGIN" />
   <meta name="viewport" content="width=device-width" />
+  <meta name="description" content="<%= site.description %> <%- sidebar.about %>" />
   <title><%= pageTitle %> - <%= site.name %></title>
   <link rel="stylesheet" href="/theme/<%= site.theme %>/<%= site.theme %>.css" />
   <link rel="stylesheet" href="/css/common.css" />


### PR DESCRIPTION
ぐぐったときに表示されるタイトルとスニペット（小見出し）の内容がイマイチな感じなので、改善したい。
http://www.google.co.jp/search?aq=f&ie=UTF-8&q=sapporojs
- Index ページのみタイトルのフォーマット変更。変更前「Index - Sapporo.js」、変更後「Sapporo.js」
- description meta タグ追加。スニペットの内容としてこちらを使用してくれることを期待する。 （ただし、設定してあれば絶対にこの部分が使用されるというわけではないみたい。。。参考： http://web-marketing.zako.org/web-marketing-news/sem-news/meta-description-improve-snippets.html ）。
