### PR TITLE
[Finish #18124925] add and correct font-family for iPad and iPhone

### DIFF
--- a/public/theme/sunlight/sunlight.css
+++ b/public/theme/sunlight/sunlight.css
@@ -45,7 +45,7 @@ body {
 
 /* font and letter settings */
 body {
-    font-family: "sans-serif";
+    font-family: sans-serif;
     color: #4b4b4b;
 }
 
@@ -54,7 +54,7 @@ div.textBody, dd {
 }
 
 .siteName, .description, h1, h2, #globalNavi {
-    font-family: "Impact", "FreeSans", "sans-serif";
+    font-family: "Impact", "FreeSans", "Verdana-Bold", sans-serif;
     font-weight: normal;
     margin-top: 0.4em;
     margin-bottom: 0;
@@ -385,7 +385,7 @@ p.siteName a:hover {
 .textBody h2 {
     margin-top: 0.8em;
     padding: 2px 0 0 4px;
-    font-family: "sans-serif";
+    font-family: sans-serif;
     font-size: 123.1%;
     width: 560px;
     border-left: 5px solid;


### PR DESCRIPTION
次のストーリーの実装です。
https://www.pivotaltracker.com/story/show/18124925

iPad, iPhone でも使用可能であるというフォントを選択しています。
mac 環境で確認出来ていないので、念のため確認してもらえると助かります。
