### PR TITLE
mac環境にて日付の下側が切れているのを修正

### DIFF
--- a/public/theme/sunlight/sunlight.css
+++ b/public/theme/sunlight/sunlight.css
@@ -190,20 +190,12 @@ div.entry ul.info li {
     display: inline;
 }
 
-div.entry ul.info .date {
-    float: left;
-    display: block;
-    width: 10em;
-    height: 1em;
-    overflow: hidden;
-}
-
 div.entry ul.info .update {
     display: none;
 }
 
 div.entry ul.info .category {
-    margin-left: -3.8em;
+    margin-left: 0.2em;
     text-transform: uppercase;
     font-weight: bold;
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/18111973
timezone を含むフォーマットに変更します。
