### PR TITLE
現在ページを見ている人の数字がはみ出しているのを修正

### DIFF
--- a/views/js/counter.ejs
+++ b/views/js/counter.ejs
@@ -5,6 +5,7 @@
       .attr('align', 'center')
       .css({
         'font-size': '3em',
+        'line-height': '1',
         'top': 0,
         'left': w.width() - counter.width(),
         'width': 50,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/18289245

line-hight の指定の問題と思われます。
以下の環境で元のコードでの事象の発生と、対応版コードで修正されることを確認しました。
- firefox on windows
- Safari on iPad
