### PR TITLE
UPDATES欄のコミットコメントのはみ出しを修正しました

### DIFF
--- a/_sass/sunlight/_updates.sass
+++ b/_sass/sunlight/_updates.sass
@@ -12,7 +12,15 @@ ul.updates
     border-bottom: 1px solid #eee
 
     .commit-row
+      position: relative
       white-space: nowrap
+
+      .author-icon
+        position: absolute
+        bottom: 0
+
+      .commit-info
+        margin-left: 34px
 
     img
       width: 20px
@@ -32,8 +40,7 @@ ul.updates
       padding: 0px
 
     span
-      display: inline-block
-      height: 100%
+      display: block
 
   li.loading
     text-align: center

--- a/_sass/sunlight/_updates.sass
+++ b/_sass/sunlight/_updates.sass
@@ -22,6 +22,14 @@ ul.updates
       .commit-info
         margin-left: 34px
 
+        > a
+          // On chrome, `text-overflow` effects only immediate children texts.
+          display: block          // `text-overflow` effects only `block`
+          padding-top: 4px        // instead of line-heigt, make block heigher
+          padding-bottom: 2px     // instead of line-heigt, make block heigher
+          overflow: hidden
+          text-overflow: ellipsis // replace overflowed letters with "..."
+
     img
       width: 20px
       height: 20px

--- a/css/sunlight.css
+++ b/css/sunlight.css
@@ -262,6 +262,12 @@ ul.updates {
         bottom: 0; }
       ul.updates li .commit-row .commit-info {
         margin-left: 34px; }
+        ul.updates li .commit-row .commit-info > a {
+          display: block;
+          padding-top: 4px;
+          padding-bottom: 2px;
+          overflow: hidden;
+          text-overflow: ellipsis; }
     ul.updates li img {
       width: 20px;
       height: 20px;

--- a/css/sunlight.css
+++ b/css/sunlight.css
@@ -255,7 +255,13 @@ ul.updates {
     list-style: none;
     border-bottom: 1px solid #eeeeee; }
     ul.updates li .commit-row {
+      position: relative;
       white-space: nowrap; }
+      ul.updates li .commit-row .author-icon {
+        position: absolute;
+        bottom: 0; }
+      ul.updates li .commit-row .commit-info {
+        margin-left: 34px; }
     ul.updates li img {
       width: 20px;
       height: 20px;
@@ -270,8 +276,7 @@ ul.updates {
       margin: 0px;
       padding: 0px; }
     ul.updates li span {
-      display: inline-block;
-      height: 100%; }
+      display: block; }
   ul.updates li.loading {
     text-align: center;
     background-image: url("../images/ajax-loader.gif");

--- a/js/updates_from_gh.js
+++ b/js/updates_from_gh.js
@@ -1,6 +1,5 @@
 jQuery(function($) {
   var REPO_NAME = 'sapporojs/sapporojs.org';
-  var MAX_MESSAGE_LENGTH = 30;
 
   // method definition
   var getUpdates = function(callback) {
@@ -21,11 +20,7 @@ jQuery(function($) {
     ,     '</span>'
     ,     '<span class="commit-info">'
     ,       '<a href="https://github.com/'+REPO_NAME+'/commit/<%- sha %>" target="_blank">'
-    ,         '<% if (commit.message.length < '+MAX_MESSAGE_LENGTH+') { %>'
-    ,            '<%- commit.message %>'
-    ,         '<% } else { %>'
-    ,            '<%- commit.message.split("").splice(0, '+MAX_MESSAGE_LENGTH+').join("") %>...'
-    ,         '<% } %>'
+    ,         '<%- commit.message %>'
     ,       '</a>'
     ,       '<div class="authorship">'
     ,         '<a href="https://github.com/<%- author.login %>" target="_blank">'


### PR DESCRIPTION
UPDATES欄からコミットコメントがはみ出してるなぁと思ったので修正しました。
FirefoxとChrome確認済み。

修正前:
![before](http://cloud.github.com/downloads/sapporojs/sapporojs.org/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202012-11-20%2022.53.17.png)

修正後:
![after](http://cloud.github.com/downloads/sapporojs/sapporojs.org/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202012-11-20%2022.53.57.png)
